### PR TITLE
feat: transmit route params

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ function makePromise(multer, name) {
 
     return (ctx, next) => {
       return new Promise((resolve, reject) => {
-        middleware(ctx.req, ctx.res, err => {
+        const req = ctx.req;
+        req.params = ctx.params;
+        middleware(req, ctx.res, err => {
           if (err) return reject(err);
           if ('request' in ctx) {
             if (ctx.req.body) {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
       "node/no-deprecated-api": "off",
       "no-unused-vars": "off",
       "no-prototype-builtins": "off",
-      "prefer-rest-params": "off"
+      "prefer-rest-params": "off",
+      "prefer-destructuring": "off"
     }
   }
 }

--- a/test/koa-integration.js
+++ b/test/koa-integration.js
@@ -119,4 +119,37 @@ describe('Koa Integration', () => {
       done();
     });
   });
+
+  it('should transmit route params', done => {
+    let receivedParams;
+    const upload = multer({
+      dest: (req, file, cb) => {
+        receivedParams = req.params;
+        cb(null, '.');
+      }
+    });
+    const router = new Router();
+    const form = new FormData();
+
+    form.append('avatar', util.file('large.jpg'));
+
+    router.post('/upload/:a/:b', upload.single('avatar'), (ctx, next) => {
+      ctx.status = 200;
+      ctx.body = 'SUCCESS';
+    });
+
+    app.use(router.routes());
+    app.use(router.allowedMethods());
+
+    submitForm(form, '/upload/A/2', (err, res, body) => {
+      assert.ifError(err);
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(receivedParams, {
+        a: 'A',
+        b: '2'
+      });
+
+      done();
+    });
+  });
 });


### PR DESCRIPTION
I needed this in order to be able to use route params in `DiskStorage`'s `destination` function

Hope it helps others